### PR TITLE
added initial get-block-spends

### DIFF
--- a/src/chia-dotnet.tests/Factory.cs
+++ b/src/chia-dotnet.tests/Factory.cs
@@ -9,7 +9,7 @@ namespace chia.dotnet.tests
     internal static class Factory
     {
         // this is the ip address of the chia node
-        private const string NodeHostAddress = "former";
+        private const string NodeHostAddress = "127.0.0.1";
 
         public static HttpRpcClient CreateDirectRpcClientFromHardcodedLocation(int port, string endpointName)
         {
@@ -20,8 +20,8 @@ namespace chia.dotnet.tests
                 //KeyPath = @"\\wsl$/Ubuntu-20.04/home/don/.chia/mainnet/config/ssl/full_node/private_full_node.key",
                 //CertPath = @"C:\Users\dkack\.rchia\certs\chiapas\private_daemon.crt",
                 //KeyPath = @"C:\Users\dkack\.rchia\certs\chiapas\private_daemon.key",
-                CertPath = $@"C:\Users\dkack\.rchia\certs\{NodeHostAddress}\private_{endpointName}.crt",
-                KeyPath = $@"C:\Users\dkack\.rchia\certs\{NodeHostAddress}\private_{endpointName}.key",
+                // CertPath = $@"/home/kev/.chia/mainnet/config/ssl/daemon/private_{endpointName}.crt",
+                // KeyPath = $@"/home/kev/.chia/mainnet/config/ssl/daemon/private_{endpointName}.key",
                 //CertPath = @"C:\Users\dkack\.rchia\certs\chiapas\private_full_node.crt",
                 //KeyPath = @"C:\Users\dkack\.rchia\certs\chiapas\private_full_node.key",
             };
@@ -43,8 +43,8 @@ namespace chia.dotnet.tests
             var endpoint = new EndpointInfo()
             {
                 Uri = new Uri($"wss://{NodeHostAddress}:55400"),
-                CertPath = $@"C:\Users\dkack\.rchia\certs\{NodeHostAddress}\private_daemon.crt",
-                KeyPath = $@"C:\Users\dkack\.rchia\certs\{NodeHostAddress}\private_daemon.key",
+                // CertPath = $@"/home/kev/.chia/mainnet/config/ssl/daemon/private_daemon.crt",
+                // KeyPath = $@"/home/kev/.chia/mainnet/config/ssl/daemon/private_daemon.key",
                 //CertPath = @"\\wsl$\Ubuntu-20.04\home\don\.chia\mainnet\config\ssl\daemon\private_daemon.crt",
                 //KeyPath = @"\\wsl$\Ubuntu-20.04\home\don\.chia\mainnet\config\ssl\daemon\private_daemon.key",
                 //CertPath = @"\\wsl.localhost\Ubuntu\home\don\.chia\mainnet\config\ssl\daemon\private_daemon.crt",

--- a/src/chia-dotnet.tests/FullNodeProxyTests.cs
+++ b/src/chia-dotnet.tests/FullNodeProxyTests.cs
@@ -225,6 +225,21 @@ namespace chia.dotnet.tests
 
             Assert.IsNotNull(additionsAndRemovals);
         }
+        
+        
+        [TestMethod()]
+        public async Task GetBlockSpends()
+        {
+            // Arrange
+            var header = "0xaa8425c198253b96a15c40e32ef4c1fd36e751f0ff9a90199e8751df381eac71"; //hash from today
+            
+            // Act
+            using var cts = new CancellationTokenSource(15000);
+            var spends = await _theFullNode.GetBlockSpends(header, cts.Token);
+            
+            // Assert
+            Assert.IsNotNull(spends);
+        }
 
         [TestMethod()]
         public async Task GetAllMempoolItems()

--- a/src/chia-dotnet/ChiaTypes/BlockSpend.cs
+++ b/src/chia-dotnet/ChiaTypes/BlockSpend.cs
@@ -1,17 +1,18 @@
 ﻿using System;
 
-namespace chia.dotnet;
-
-public record BlockSpend
+namespace chia.dotnet
 {
-    public string Puzzle_Reveal { get; set; }
-    public string Solution { get; set; }
-    public BlockCoinSpend Coin { get; set; }
-}
+    public record BlockSpend
+    {
+        public string PuzzleReveal { get; init; } = string.Empty;
+        public string Solution { get; init; } = string.Empty;
+        public BlockCoinSpend Coin { get; init; } = new();
+    }
 
-public record BlockCoinSpend
-{
-    public Int64 Amount { get; set; }
-    public string Parent_Coin_Info { get; set; }
-    public string Puzzle_Hash { get; set; }
+    public record BlockCoinSpend
+    {
+        public Int64 Amount { get; init; }
+        public string ParentCoinInfo { get; init; } = string.Empty;
+        public string PuzzleHash { get; init; } = string.Empty;
+    }
 }

--- a/src/chia-dotnet/ChiaTypes/BlockSpend.cs
+++ b/src/chia-dotnet/ChiaTypes/BlockSpend.cs
@@ -1,0 +1,17 @@
+﻿using System;
+
+namespace chia.dotnet;
+
+public record BlockSpend
+{
+    public string Puzzle_Reveal { get; set; }
+    public string Solution { get; set; }
+    public BlockCoinSpend Coin { get; set; }
+}
+
+public record BlockCoinSpend
+{
+    public Int64 Amount { get; set; }
+    public string Parent_Coin_Info { get; set; }
+    public string Puzzle_Hash { get; set; }
+}

--- a/src/chia-dotnet/FullNodeProxy.cs
+++ b/src/chia-dotnet/FullNodeProxy.cs
@@ -358,6 +358,18 @@ namespace chia.dotnet
                 );
         }
 
+        public async Task<IEnumerable<BlockSpend>> GetBlockSpends(string headerhash, CancellationToken cancellationToken = default)
+        {
+            if (string.IsNullOrEmpty(headerhash))
+            {
+                throw new ArgumentNullException(nameof(headerhash));
+            }
+            dynamic data = new ExpandoObject();
+            data.header_hash = headerhash;
+
+            return await SendMessage<IEnumerable<BlockSpend>>("get_block_spends", data, "block_spends", cancellationToken).ConfigureAwait(false);
+        }
+        
         /// <summary>
         /// Returns all items in the mempool.
         /// </summary>

--- a/src/chia-dotnet/FullNodeProxy.cs
+++ b/src/chia-dotnet/FullNodeProxy.cs
@@ -369,7 +369,7 @@ namespace chia.dotnet
 
             return await SendMessage<IEnumerable<BlockSpend>>("get_block_spends", data, "block_spends", cancellationToken).ConfigureAwait(false);
         }
-        
+
         /// <summary>
         /// Returns all items in the mempool.
         /// </summary>


### PR DESCRIPTION
Added [get_block_spends](https://docs.chia.net/full-node-rpc/#get_block_spends)

Added a test to show it works. 

A few things to note.
- The header hash is recent, so will most likely fail if not fully synced. This would probably be best to have a header hash from way back or one from the simulator which would return a known result.
- I've avoided doing an assertcollection.* until the above is more robust.
