### PR TITLE
update gitignore to ignore jetbrains .idea folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@
 ##
 ## Get latest from https://github.com/github/gitignore/blob/master/VisualStudio.gitignore
 
+# Jetbrains rider 
+.idea/
+
 # User-specific files
 *.rsuser
 *.suo


### PR DESCRIPTION
Jetbrains rider generates an .idea folder which constantly gets generated when building the solution. 

This small PR ignores the .idea folder.

Reference:
https://rider-support.jetbrains.com/hc/en-us/articles/207097529-What-is-the-idea-folder-